### PR TITLE
Add Swift syntax coloring to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It also provides a `KeyboardObservingView` that adjusts it's content to avoid th
 
 In your SceneDelegate.swift file, add a `Keyboard` property, and add it to your scene's environment.
 
-```
+```swift
 import KeyboardObserving
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -62,7 +62,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 Add your view's content inside of a `KeyboardObservingView` .
 
-```
+```swift
 import KeyboardObserving
 
 struct YourView: View {


### PR DESCRIPTION
### Changes
- adds language specifier (Swift) for syntax highlighting

Before 
<img width="809" alt="image" src="https://user-images.githubusercontent.com/10351428/63291371-5eeabf80-c291-11e9-9257-908cf3f630f8.png">

After
<img width="792" alt="Screen Shot 2019-08-19 at 2 54 59 PM" src="https://user-images.githubusercontent.com/10351428/63291333-53979400-c291-11e9-9176-c51ac7b2b102.png">
