### PR TITLE
In Mac catalyst apps, KeyboardObservingView was causing stuttering behavior during live resize

### DIFF
--- a/Sources/KeyboardObserving/HiddenWhenKeyboardVisibleView.swift
+++ b/Sources/KeyboardObserving/HiddenWhenKeyboardVisibleView.swift
@@ -1,0 +1,31 @@
+//
+//  File.swift
+//  
+//
+//  Created by Joseph A. Wardell on 10/24/19.
+//
+
+import SwiftUI
+
+public struct HiddenWhenKeyboardVisibleView<Content: View>: View {
+
+  @EnvironmentObject var keyboard: Keyboard
+
+  let content: Content
+
+  public init(@ViewBuilder builder: () -> Content) {
+    self.content = builder()
+  }
+
+  public var body: some View {
+  
+  #if targetEnvironment(macCatalyst)
+  return content
+  #else
+
+    return content
+        .opacity(keyboard.state.height == 0 ? 1.0 : 0.0)
+        .animation(.easeOut(duration: keyboard.state.animationDuration))
+  #endif
+  }
+}

--- a/Sources/KeyboardObserving/KeyboardObservingView.swift
+++ b/Sources/KeyboardObserving/KeyboardObservingView.swift
@@ -21,9 +21,20 @@ public struct KeyboardObservingView<Content: View>: View {
   }
 
   public var body: some View {
-      content
-        .padding([.bottom], keyboard.state.height)
-        .edgesIgnoringSafeArea((keyboard.state.height > 0) ? [.bottom] : [])
-        .animation(.easeOut(duration: keyboard.state.animationDuration))
+  
+  // for some reason, this can cause stuttering
+  // in mac catalyst applications
+  // and we don't need to observe the keyboard
+  // in mac catalist anyway
+  // so only return the content in mac catalyst
+  // (I think it's the animation, but I'm not sure)
+  #if targetEnvironment(macCatalyst)
+  return content
+  #else
+  return content
+      .padding([.bottom], keyboard.state.height)
+      .edgesIgnoringSafeArea((keyboard.state.height > 0) ? [.bottom] : [])
+      .animation(.easeOut(duration: keyboard.state.animationDuration))
+  #endif
   }
 }


### PR DESCRIPTION
KeyboardObservingView was causing stuttering behavior during live resize in mac catalyst

This could cause problems in cross-platform project (like mine)
Since we don't need to observe the keyboard in mac anyway,
we simply don't send back the modifications when in mac catalyst