### PR TITLE
Add podspec to enable Cocoapods installs

### DIFF
--- a/KeyboardObserving.podspec
+++ b/KeyboardObserving.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'KeyboardObserving'
-  spec.version = '0.2.0'
+  spec.version = '0.2.1'
   spec.license = { type: 'MIT' }
   spec.homepage = 'https://github.com/nickffox/KeyboardObserving'
   spec.authors = { 'Nick Fox' => 'nicholas.f.fox@gmail.com' }

--- a/KeyboardObserving.podspec
+++ b/KeyboardObserving.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |spec|
+  spec.name = 'KeyboardObserving'
+  spec.version = '0.2.0'
+  spec.license = { type: 'MIT' }
+  spec.homepage = 'https://github.com/nickffox/KeyboardObserving'
+  spec.authors = { 'Nick Fox' => 'nicholas.f.fox@gmail.com' }
+  spec.summary = 'A Combine-based way to observe and adjust for Keyboard notifications in SwiftUI'
+  spec.source = {
+    git: 'https://github.com/nickffox/KeyboardObserving.git',
+    tag: "v#{spec.version}"
+  }
+  spec.source_files = 'Sources/KeyboardObserving/**/*.swift'
+  spec.platform = :ios, '13.0'
+  spec.swift_version = '5.1'
+end


### PR DESCRIPTION
Fixes https://github.com/nickffox/KeyboardObserving/issues/5

```
$ pod lib lint --no-clean

 -> KeyboardObserving (0.2.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'KeyboardObserving' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Pods-App' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'App' from project 'App')
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')

Pods workspace available at `/var/folders/hr/v4vtphl130zczzkbpdkbs7qm0000gn/T/CocoaPods-Lint-20191114-20444-soqu5a-KeyboardObserving/App.xcworkspace` for inspection.

KeyboardObserving passed validation.
```