### PR TITLE
Replaced implicit animation modifiers with explicit animation ('withA…

### DIFF
--- a/Sources/KeyboardObserving/HiddenWhenKeyboardVisibleView.swift
+++ b/Sources/KeyboardObserving/HiddenWhenKeyboardVisibleView.swift
@@ -22,7 +22,7 @@ public struct HiddenWhenKeyboardVisibleView<Content: View>: View {
   #if targetEnvironment(macCatalyst)
   return content
   #else
-  return withAnimation(.easeOut(duration: keyboard.state.animationDuration)) {
+    return withAnimation(.easeOut(duration: keyboard.state.animationDuration)) {
     content
         .opacity(keyboard.state.height == 0 ? 1.0 : 0.0)
     }

--- a/Sources/KeyboardObserving/HiddenWhenKeyboardVisibleView.swift
+++ b/Sources/KeyboardObserving/HiddenWhenKeyboardVisibleView.swift
@@ -22,10 +22,10 @@ public struct HiddenWhenKeyboardVisibleView<Content: View>: View {
   #if targetEnvironment(macCatalyst)
   return content
   #else
-
-    return content
+  return withAnimation(.easeOut(duration: keyboard.state.animationDuration)) {
+    content
         .opacity(keyboard.state.height == 0 ? 1.0 : 0.0)
-        .animation(.easeOut(duration: keyboard.state.animationDuration))
+    }
   #endif
   }
 }

--- a/Sources/KeyboardObserving/KeyboardObservingView.swift
+++ b/Sources/KeyboardObserving/KeyboardObservingView.swift
@@ -31,10 +31,11 @@ public struct KeyboardObservingView<Content: View>: View {
   #if targetEnvironment(macCatalyst)
   return content
   #else
-  return content
+  return withAnimation(.easeOut(duration: keyboard.state.animationDuration)) {
+     content
       .padding([.bottom], keyboard.state.height)
       .edgesIgnoringSafeArea((keyboard.state.height > 0) ? [.bottom] : [])
-      .animation(.easeOut(duration: keyboard.state.animationDuration))
+     }
   #endif
   }
 }

--- a/Sources/KeyboardObserving/viewmodifier/KeyboardObserving.swift
+++ b/Sources/KeyboardObserving/viewmodifier/KeyboardObserving.swift
@@ -16,15 +16,16 @@ struct KeyboardObserving: ViewModifier {
   @State var keyboardAnimationDuration: Double = 0
 
   func body(content: Content) -> some View {
+    return withAnimation(.easeOut(duration: keyboardAnimationDuration)) {
     content
       .padding([.bottom], keyboardHeight)
       .edgesIgnoringSafeArea((keyboardHeight > 0) ? [.bottom] : [])
-      .animation(.easeOut(duration: keyboardAnimationDuration))
       .onReceive(
         NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)
           .receive(on: RunLoop.main),
         perform: updateKeyboardHeight
       )
+    }
   }
 
   func updateKeyboardHeight(_ notification: Notification) {


### PR DESCRIPTION
Replaced implicit animation modifiers with explicit animation ('withAnimation'), in order to animate all the affected views returned in the content view, thus preventing non-keyboard animation to stuck.
(Attached sample project)
[KeyboardObservingSample.zip](https://github.com/nickffox/KeyboardObserving/files/4319502/KeyboardObservingSample.zip)
