### PR TITLE
[Alternative method of modifying views] Switched from modifying frame to using an offset

### DIFF
--- a/Sources/KeyboardObserving/viewmodifier/KeyboardObserving.swift
+++ b/Sources/KeyboardObserving/viewmodifier/KeyboardObserving.swift
@@ -17,9 +17,8 @@ struct KeyboardObserving: ViewModifier {
 
   func body(content: Content) -> some View {
     content
-      .padding([.bottom], keyboardHeight)
+      .offset(x: 0, y: -keyboardHeight)
       .edgesIgnoringSafeArea((keyboardHeight > 0) ? [.bottom] : [])
-      .animation(.easeOut(duration: keyboardAnimationDuration))
       .onReceive(
         NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)
           .receive(on: RunLoop.main),
@@ -35,12 +34,15 @@ struct KeyboardObserving: ViewModifier {
 
     guard let keyboardFrame = info[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
       else { return }
-    // If the top of the frame is at the bottom of the screen, set the height to 0.
-    if keyboardFrame.origin.y == UIScreen.main.bounds.height {
-      keyboardHeight = 0
-    } else {
-      // IMPORTANT: This height will _include_ the SafeAreaInset height.
-      keyboardHeight = keyboardFrame.height + offset
+    
+    withAnimation(.easeInOut(duration: keyboardAnimationDuration)) {
+        // If the top of the frame is at the bottom of the screen, set the height to 0.
+        if keyboardFrame.origin.y == UIScreen.main.bounds.height {
+          keyboardHeight = 0
+        } else {
+          // IMPORTANT: This height will _include_ the SafeAreaInset height.
+          keyboardHeight = keyboardFrame.height + offset
+        }
     }
   }
 }


### PR DESCRIPTION
Thanks for creating this Nick. I had a use case which required a slight modification that I thought might be useful for others.

Let's say we have this:

```
struct TestView: View {
    
    @State var text: String = ""
    
    var body: some View {
        VStack(spacing: 0) {
            Color.blue.frame(height: 300)
            
            Color.red
            
            TextField("Type something", text: $text)
                .frame(height: 100)
                .foregroundColor(Color.white)
                .background(Color.black)
        }
        .keyboardObserving()
    }
}
```

Using the current `KeyboardObserving`, the result looks like this:
![before](https://user-images.githubusercontent.com/1586049/99247855-8c485500-27d5-11eb-82d3-8af8ad35a528.gif)

You can see it modifies the relative sizes of Blue and Red since Blue is constrained while Red is not.

When I wrote my own keyboard avoiders before SwiftUI, I found messing with the frames sometimes gave hard to debug results so I had always preferred to simply use a transformation on the underlying layer and translate everything up.

This gives the following result:

![after](https://user-images.githubusercontent.com/1586049/99248389-5c4d8180-27d6-11eb-8045-2e943c5c55e9.gif)

It may not be what your extension intends but thought it was a nice option to have.